### PR TITLE
Remove code duplication between Docker repo and Ansible role repo

### DIFF
--- a/provisioning/build-vars.yml
+++ b/provisioning/build-vars.yml
@@ -1,6 +1,3 @@
 # See https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml and
 # https://github.com/gpii-ops/ansible-preferences-server/blob/master/defaults/main.yml
 # for what can be configured in a build
-
-nodejs_app_name: universal
-nodejs_app_install_dir: /opt/gpii/node_modules/{{ nodejs_app_name }}

--- a/provisioning/run-vars.yml
+++ b/provisioning/run-vars.yml
@@ -2,17 +2,3 @@
 ---
 preferences_server_couchdb_host_address: "{{ lookup('env', 'COUCHDB_HOST_ADDRESS')  | default('localhost:5984',true) }}"
 preferences_server_environment: "{{ lookup('env', 'NODE_ENV') | default('gpii.preferencesServer.config.production',true) }}"
-
-# Although this has been already specified in the GPII/universal, it's needed here for the deploy phase again.
-nodejs_app_name: universal
-nodejs_app_start_script: gpii.js
-
-# self-test configuration for CONTAINER_TEST mode
-nodejs_app_host_address: 127.0.0.1
-nodejs_app_tcp_port: 8082
-nodejs_app_test_http_endpoint: /preferences/carla
-nodejs_app_test_http_status_code: 200
-nodejs_app_test_string: registry.gpii.net
-
-# install directory for universal from parent container
-nodejs_app_install_dir: /opt/gpii/node_modules/{{ nodejs_app_name }}


### PR DESCRIPTION
This stuff exists in the Ansible role preferences-server already.